### PR TITLE
Replace URI.escape/unescape

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,9 +30,9 @@ https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/o
 
     def to_query
       q = "access_token=#{token}&token_type=bearer"
-      q << "&state=#{URI.escape(state)}" if @state
+      q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
       q << "&expires_in=#{expires_in}" if expires_at
-      q << "&scope=#{URI.escape(scope)}" if scope
+      q << "&scope=#{URI::DEFAULT_PARSER.escape(scope)}" if scope
       q
     end
 
@@ -66,7 +66,7 @@ https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/o
 
     def to_query
       q = "code=#{token}"
-      q << "&state=#{URI.escape(state)}" if @state
+      q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
       q
     end
 

--- a/generators/oauth_provider/templates/oauth2_token.rb
+++ b/generators/oauth_provider/templates/oauth2_token.rb
@@ -7,10 +7,11 @@ class Oauth2Token < AccessToken
   end
 
   def to_query
+    parser = URI::RFC2396_Parser.new
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{parser.escape(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{URI.escape(scope)}" if scope
+    q << "&scope=#{parser.escape(scope)}" if scope
     q
   end
 

--- a/generators/oauth_provider/templates/oauth2_token.rb
+++ b/generators/oauth_provider/templates/oauth2_token.rb
@@ -7,11 +7,10 @@ class Oauth2Token < AccessToken
   end
 
   def to_query
-    parser = URI::RFC2396_Parser.new
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{parser.escape(state)}" if @state
+    q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{parser.escape(scope)}" if scope
+    q << "&scope=#{URI::DEFAULT_PARSER.escape(scope)}" if scope
     q
   end
 

--- a/generators/oauth_provider/templates/oauth2_verifier.rb
+++ b/generators/oauth_provider/templates/oauth2_verifier.rb
@@ -20,7 +20,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{URI::RFC2396_Parser.new.escape(state)}" if @state
     q
   end
 

--- a/generators/oauth_provider/templates/oauth2_verifier.rb
+++ b/generators/oauth_provider/templates/oauth2_verifier.rb
@@ -20,7 +20,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI::RFC2396_Parser.new.escape(state)}" if @state
+    q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
     q
   end
 

--- a/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
+++ b/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
@@ -7,10 +7,11 @@ class Oauth2Token < AccessToken
   end
 
   def to_query
+    parser = URI::RFC2396_Parser.new
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{parser.escape(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{URI.escape(scope)}" if scope
+    q << "&scope=#{parser.escape(scope)}" if scope
     q
   end
 

--- a/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
+++ b/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
@@ -7,11 +7,10 @@ class Oauth2Token < AccessToken
   end
 
   def to_query
-    parser = URI::RFC2396_Parser.new
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{parser.escape(state)}" if @state
+    q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{parser.escape(scope)}" if scope
+    q << "&scope=#{URI::DEFAULT_PARSER.escape(scope)}" if scope
     q
   end
 

--- a/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
+++ b/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
@@ -20,7 +20,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{URI::RFC2396_Parser.new.escape(state)}" if @state
     q
   end
 

--- a/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
+++ b/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
@@ -20,7 +20,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI::RFC2396_Parser.new.escape(state)}" if @state
+    q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
     q
   end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth2_token.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth2_token.rb
@@ -7,10 +7,11 @@ class Oauth2Token < AccessToken
   end
 
   def to_query
+    parser = URI::RFC2396_Parser.new
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{parser.escape(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{URI.escape(scope)}" if scope
+    q << "&scope=#{parser.escape(scope)}" if scope
     q
   end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth2_token.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth2_token.rb
@@ -7,11 +7,10 @@ class Oauth2Token < AccessToken
   end
 
   def to_query
-    parser = URI::RFC2396_Parser.new
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{parser.escape(state)}" if @state
+    q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{parser.escape(scope)}" if scope
+    q << "&scope=#{URI::DEFAULT_PARSER.escape(scope)}" if scope
     q
   end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth2_verifier.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth2_verifier.rb
@@ -20,7 +20,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{URI::RFC2396_Parser.new.escape(state)}" if @state
     q
   end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth2_verifier.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth2_verifier.rb
@@ -20,7 +20,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI::RFC2396_Parser.new.escape(state)}" if @state
+    q << "&state=#{URI::DEFAULT_PARSER.escape(state)}" if @state
     q
   end
 

--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -108,7 +108,7 @@ module OAuth
             if user_authorizes_token?
               @token.authorize!(current_user)
               callback_url  = @token.oob? ? @token.client_application.callback_url : @token.callback_url
-              @redirect_url = URI::RFC2396_Parser.new.parse(callback_url) unless callback_url.blank?
+              @redirect_url = URI::DEFAULT_PARSER.parse(callback_url) unless callback_url.blank?
 
               unless @redirect_url.to_s.blank?
                 @redirect_url.query = @redirect_url.query.blank? ?

--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -108,7 +108,7 @@ module OAuth
             if user_authorizes_token?
               @token.authorize!(current_user)
               callback_url  = @token.oob? ? @token.client_application.callback_url : @token.callback_url
-              @redirect_url = URI.parse(callback_url) unless callback_url.blank?
+              @redirect_url = URI::RFC2396_Parser.new.parse(callback_url) unless callback_url.blank?
 
               unless @redirect_url.to_s.blank?
                 @redirect_url.query = @redirect_url.query.blank? ?

--- a/lib/oauth/provider/authorizer.rb
+++ b/lib/oauth/provider/authorizer.rb
@@ -68,16 +68,15 @@ module OAuth
       end
 
       def encode_response
-        parser = URI::RFC2396_Parser.new
         response.map do |k, v|
-          [parser.escape(k.to_s),parser.escape(v)] * "="
+          [URI::DEFAULT_PARSER.escape(k.to_s),URI::DEFAULT_PARSER.escape(v)] * "="
         end * "&"
       end
 
       protected
 
         def base_uri
-          URI::RFC2396_Parser.new.parse(params[:redirect_uri] || app.callback_url)
+          URI::DEFAULT_PARSER.parse(params[:redirect_uri] || app.callback_url)
         end
     end
   end

--- a/lib/oauth/provider/authorizer.rb
+++ b/lib/oauth/provider/authorizer.rb
@@ -68,15 +68,16 @@ module OAuth
       end
 
       def encode_response
+        parser = URI::RFC2396_Parser.new
         response.map do |k, v|
-          [URI.escape(k.to_s),URI.escape(v)] * "="
+          [parser.escape(k.to_s),parser.escape(v)] * "="
         end * "&"
       end
 
       protected
 
         def base_uri
-          URI.parse(params[:redirect_uri] || app.callback_url)
+          URI::RFC2396_Parser.new.parse(params[:redirect_uri] || app.callback_url)
         end
     end
   end


### PR DESCRIPTION
These methods are removed from Ruby 3.
We are using the URI::RFC2396_Parser to maintain current behavior.